### PR TITLE
Add configurable endpoint setting (already existed in the code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ file = "/var/edgee/components/amplitude.wasm"
 settings.amplitude_api_key = "..."
 
 # Optional configurations
+settings.amplitude_endpoint = "..."        # The default value is https://api2.amplitude.com/2/httpapi
 settings.edgee_anonymization = true        # Enable/disable data anonymization
 settings.edgee_default_consent = "pending" # Set default consent status
 ```

--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -24,5 +24,11 @@ output_path = "amplitude.wasm"
 title = "API Key"
 type = "string"
 required = true
+description = "The API key for your Amplitude project"
+
+[component.settings.amplitude_endpoint]
+title = "Endpoint (optional)"
+type = "string"
 description = """
-The API key for your Amplitude project"""
+The Endpoint for your Amplitude project. The default value is https://api2.amplitude.com/2/httpapi
+"""

--- a/src/amplitude_payload.rs
+++ b/src/amplitude_payload.rs
@@ -27,7 +27,7 @@ impl AmplitudePayload {
         .to_string();
 
         let endpoint = cred
-            .get("endpoint")
+            .get("amplitude_endpoint")
             .cloned()
             .unwrap_or(crate::DEFAULT_ENDPOINT.to_owned());
 


### PR DESCRIPTION
### Description of Changes

We forgot to define this in the component manifest.

Also, I've renamed the "endpoint" setting to "amplitude_endpoint" for coherence with the other setting names.
